### PR TITLE
DRAFT PR - Proxy instance

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -184,6 +184,7 @@ let create_wrapper = function(node_id, flow_id, ctx) {
             debugger
                 let handler = {
                     get: (target, property, receiver) => {
+                        // See https://discourse.nodered.org/t/node-red-context-monitor-a-node-to-monitor-a-node-red-context/82555/8?u=bartbutenaers
                         if (property === IDENTITY) {
                             return target
                         }


### PR DESCRIPTION
Hi @ralphwetzel,

This is a DRAFT PR, so not sure if you ever will merge it.
I simply wanted to do an experiment, in an attempt to solve my issue described [here](https://discourse.nodered.org/t/node-red-context-monitor-a-node-to-monitor-a-node-red-context/82555/8?u=bartbutenaers).

My idea was to not return the object itself to Node-RED, but a Proxy of the object:
1. You get an object from the context store, based on its key.
2. A proxy of the object is returned.
3. You update the object (via the proxy) instead of setting it.
4. The proxy sends triggers your node

For my example it seems to work.  

But it lacks some basic functionality:
+ This is a feature that should not always be active.  Because if you work like this:
   + get an object
   + change the object
   + set the object

   Then no proxy should be returned.  Otherwise both the proxy change and the 'set' will send a message.  And if you don't set the object at the end (so skipping the changes you did before), no message should be send.
+ The value will not always be an object, but e.g. a primitive.
+ ...

So unfortunately no full implementation, but just sharing some thoughts here.
But I am afraid it will never become waterproof.

Thanks for this node!
Bart